### PR TITLE
[ENG-1155] Add wiki dump for IA prototype

### DIFF
--- a/IA/tests/fixtures/wiki-metadata-response-page-1.json
+++ b/IA/tests/fixtures/wiki-metadata-response-page-1.json
@@ -1,0 +1,576 @@
+{
+    "data": [
+        {
+            "relationships": {
+                "node": {
+                    "data": {
+                        "type": "registrations",
+                        "id": "fxehm"
+                    },
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/registrations/fxehm/",
+                            "meta": {}
+                        }
+                    }
+                },
+                "user": {
+                    "data": {
+                        "type": "users",
+                        "id": "wm28y"
+                    },
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/users/wm28y/",
+                            "meta": {}
+                        }
+                    }
+                },
+                "comments": {
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/registrations/fxehm/comments/?filter%5Btarget%5D=bxk3w",
+                            "meta": {}
+                        }
+                    }
+                }
+            },
+            "links": {
+                "info": "https://localhost:8000/v2/wikis/bxk3w/",
+                "download": "https://localhost:8000/v2/wikis/bxk3w/content/",
+                "self": "https://localhost:8000/v2/wikis/bxk3w/"
+            },
+            "attributes": {
+                "kind": "file",
+                "name": "test10",
+                "date_modified": "2019-11-04T14:24:33.026155Z",
+                "extra": {
+                    "version": 1
+                },
+                "content_type": "text/markdown",
+                "path": "/bxk3w",
+                "current_user_can_comment": true,
+                "materialized_path": "/bxk3w",
+                "size": 52
+            },
+            "type": "wikis",
+            "id": "bxk3w"
+        },
+        {
+            "relationships": {
+                "node": {
+                    "data": {
+                        "type": "registrations",
+                        "id": "fxehm"
+                    },
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/registrations/fxehm/",
+                            "meta": {}
+                        }
+                    }
+                },
+                "user": {
+                    "data": {
+                        "type": "users",
+                        "id": "wm28y"
+                    },
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/users/wm28y/",
+                            "meta": {}
+                        }
+                    }
+                },
+                "comments": {
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/registrations/fxehm/comments/?filter%5Btarget%5D=j358x",
+                            "meta": {}
+                        }
+                    }
+                }
+            },
+            "links": {
+                "info": "https://localhost:8000/v2/wikis/j358x/",
+                "download": "https://localhost:8000/v2/wikis/j358x/content/",
+                "self": "https://localhost:8000/v2/wikis/j358x/"
+            },
+            "attributes": {
+                "kind": "file",
+                "name": "test9",
+                "date_modified": "2019-11-04T14:24:32.976166Z",
+                "extra": {
+                    "version": 1
+                },
+                "content_type": "text/markdown",
+                "path": "/j358x",
+                "current_user_can_comment": true,
+                "materialized_path": "/j358x",
+                "size": 52
+            },
+            "type": "wikis",
+            "id": "j358x"
+        },
+        {
+            "relationships": {
+                "node": {
+                    "data": {
+                        "type": "registrations",
+                        "id": "fxehm"
+                    },
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/registrations/fxehm/",
+                            "meta": {}
+                        }
+                    }
+                },
+                "user": {
+                    "data": {
+                        "type": "users",
+                        "id": "wm28y"
+                    },
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/users/wm28y/",
+                            "meta": {}
+                        }
+                    }
+                },
+                "comments": {
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/registrations/fxehm/comments/?filter%5Btarget%5D=tnhuv",
+                            "meta": {}
+                        }
+                    }
+                }
+            },
+            "links": {
+                "info": "https://localhost:8000/v2/wikis/tnhuv/",
+                "download": "https://localhost:8000/v2/wikis/tnhuv/content/",
+                "self": "https://localhost:8000/v2/wikis/tnhuv/"
+            },
+            "attributes": {
+                "kind": "file",
+                "name": "test8",
+                "date_modified": "2019-11-04T14:24:32.925206Z",
+                "extra": {
+                    "version": 1
+                },
+                "content_type": "text/markdown",
+                "path": "/tnhuv",
+                "current_user_can_comment": true,
+                "materialized_path": "/tnhuv",
+                "size": 52
+            },
+            "type": "wikis",
+            "id": "tnhuv"
+        },
+        {
+            "relationships": {
+                "node": {
+                    "data": {
+                        "type": "registrations",
+                        "id": "fxehm"
+                    },
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/registrations/fxehm/",
+                            "meta": {}
+                        }
+                    }
+                },
+                "user": {
+                    "data": {
+                        "type": "users",
+                        "id": "wm28y"
+                    },
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/users/wm28y/",
+                            "meta": {}
+                        }
+                    }
+                },
+                "comments": {
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/registrations/fxehm/comments/?filter%5Btarget%5D=duj6b",
+                            "meta": {}
+                        }
+                    }
+                }
+            },
+            "links": {
+                "info": "https://localhost:8000/v2/wikis/duj6b/",
+                "download": "https://localhost:8000/v2/wikis/duj6b/content/",
+                "self": "https://localhost:8000/v2/wikis/duj6b/"
+            },
+            "attributes": {
+                "kind": "file",
+                "name": "test7",
+                "date_modified": "2019-11-04T14:24:32.873617Z",
+                "extra": {
+                    "version": 1
+                },
+                "content_type": "text/markdown",
+                "path": "/duj6b",
+                "current_user_can_comment": true,
+                "materialized_path": "/duj6b",
+                "size": 52
+            },
+            "type": "wikis",
+            "id": "duj6b"
+        },
+        {
+            "relationships": {
+                "node": {
+                    "data": {
+                        "type": "registrations",
+                        "id": "fxehm"
+                    },
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/registrations/fxehm/",
+                            "meta": {}
+                        }
+                    }
+                },
+                "user": {
+                    "data": {
+                        "type": "users",
+                        "id": "wm28y"
+                    },
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/users/wm28y/",
+                            "meta": {}
+                        }
+                    }
+                },
+                "comments": {
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/registrations/fxehm/comments/?filter%5Btarget%5D=etbp2",
+                            "meta": {}
+                        }
+                    }
+                }
+            },
+            "links": {
+                "info": "https://localhost:8000/v2/wikis/etbp2/",
+                "download": "https://localhost:8000/v2/wikis/etbp2/content/",
+                "self": "https://localhost:8000/v2/wikis/etbp2/"
+            },
+            "attributes": {
+                "kind": "file",
+                "name": "test6",
+                "date_modified": "2019-11-04T14:24:32.823941Z",
+                "extra": {
+                    "version": 1
+                },
+                "content_type": "text/markdown",
+                "path": "/etbp2",
+                "current_user_can_comment": true,
+                "materialized_path": "/etbp2",
+                "size": 52
+            },
+            "type": "wikis",
+            "id": "etbp2"
+        },
+        {
+            "relationships": {
+                "node": {
+                    "data": {
+                        "type": "registrations",
+                        "id": "fxehm"
+                    },
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/registrations/fxehm/",
+                            "meta": {}
+                        }
+                    }
+                },
+                "user": {
+                    "data": {
+                        "type": "users",
+                        "id": "wm28y"
+                    },
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/users/wm28y/",
+                            "meta": {}
+                        }
+                    }
+                },
+                "comments": {
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/registrations/fxehm/comments/?filter%5Btarget%5D=em2gy",
+                            "meta": {}
+                        }
+                    }
+                }
+            },
+            "links": {
+                "info": "https://localhost:8000/v2/wikis/em2gy/",
+                "download": "https://localhost:8000/v2/wikis/em2gy/content/",
+                "self": "https://localhost:8000/v2/wikis/em2gy/"
+            },
+            "attributes": {
+                "kind": "file",
+                "name": "test5",
+                "date_modified": "2019-11-04T14:24:32.775162Z",
+                "extra": {
+                    "version": 1
+                },
+                "content_type": "text/markdown",
+                "path": "/em2gy",
+                "current_user_can_comment": true,
+                "materialized_path": "/em2gy",
+                "size": 52
+            },
+            "type": "wikis",
+            "id": "em2gy"
+        },
+        {
+            "relationships": {
+                "node": {
+                    "data": {
+                        "type": "registrations",
+                        "id": "fxehm"
+                    },
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/registrations/fxehm/",
+                            "meta": {}
+                        }
+                    }
+                },
+                "user": {
+                    "data": {
+                        "type": "users",
+                        "id": "wm28y"
+                    },
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/users/wm28y/",
+                            "meta": {}
+                        }
+                    }
+                },
+                "comments": {
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/registrations/fxehm/comments/?filter%5Btarget%5D=fcs2t",
+                            "meta": {}
+                        }
+                    }
+                }
+            },
+            "links": {
+                "info": "https://localhost:8000/v2/wikis/fcs2t/",
+                "download": "https://localhost:8000/v2/wikis/fcs2t/content/",
+                "self": "https://localhost:8000/v2/wikis/fcs2t/"
+            },
+            "attributes": {
+                "kind": "file",
+                "name": "test4",
+                "date_modified": "2019-11-04T14:24:32.714625Z",
+                "extra": {
+                    "version": 1
+                },
+                "content_type": "text/markdown",
+                "path": "/fcs2t",
+                "current_user_can_comment": true,
+                "materialized_path": "/fcs2t",
+                "size": 52
+            },
+            "type": "wikis",
+            "id": "fcs2t"
+        },
+        {
+            "relationships": {
+                "node": {
+                    "data": {
+                        "type": "registrations",
+                        "id": "fxehm"
+                    },
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/registrations/fxehm/",
+                            "meta": {}
+                        }
+                    }
+                },
+                "user": {
+                    "data": {
+                        "type": "users",
+                        "id": "wm28y"
+                    },
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/users/wm28y/",
+                            "meta": {}
+                        }
+                    }
+                },
+                "comments": {
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/registrations/fxehm/comments/?filter%5Btarget%5D=r4pyn",
+                            "meta": {}
+                        }
+                    }
+                }
+            },
+            "links": {
+                "info": "https://localhost:8000/v2/wikis/r4pyn/",
+                "download": "https://localhost:8000/v2/wikis/r4pyn/content/",
+                "self": "https://localhost:8000/v2/wikis/r4pyn/"
+            },
+            "attributes": {
+                "kind": "file",
+                "name": "test3",
+                "date_modified": "2019-11-04T14:24:32.638847Z",
+                "extra": {
+                    "version": 2
+                },
+                "content_type": "text/markdown",
+                "path": "/r4pyn",
+                "current_user_can_comment": true,
+                "materialized_path": "/r4pyn",
+                "size": 88
+            },
+            "type": "wikis",
+            "id": "r4pyn"
+        },
+        {
+            "relationships": {
+                "node": {
+                    "data": {
+                        "type": "registrations",
+                        "id": "fxehm"
+                    },
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/registrations/fxehm/",
+                            "meta": {}
+                        }
+                    }
+                },
+                "user": {
+                    "data": {
+                        "type": "users",
+                        "id": "wm28y"
+                    },
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/users/wm28y/",
+                            "meta": {}
+                        }
+                    }
+                },
+                "comments": {
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/registrations/fxehm/comments/?filter%5Btarget%5D=dtns3",
+                            "meta": {}
+                        }
+                    }
+                }
+            },
+            "links": {
+                "info": "https://localhost:8000/v2/wikis/dtns3/",
+                "download": "https://localhost:8000/v2/wikis/dtns3/content/",
+                "self": "https://localhost:8000/v2/wikis/dtns3/"
+            },
+            "attributes": {
+                "kind": "file",
+                "name": "home",
+                "date_modified": "2019-10-31T14:55:02.352330Z",
+                "extra": {
+                    "version": 1
+                },
+                "content_type": "text/markdown",
+                "path": "/dtns3",
+                "current_user_can_comment": true,
+                "materialized_path": "/dtns3",
+                "size": 860
+            },
+            "type": "wikis",
+            "id": "dtns3"
+        },
+        {
+            "relationships": {
+                "node": {
+                    "data": {
+                        "type": "registrations",
+                        "id": "fxehm"
+                    },
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/registrations/fxehm/",
+                            "meta": {}
+                        }
+                    }
+                },
+                "user": {
+                    "data": {
+                        "type": "users",
+                        "id": "wm28y"
+                    },
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/users/wm28y/",
+                            "meta": {}
+                        }
+                    }
+                },
+                "comments": {
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/registrations/fxehm/comments/?filter%5Btarget%5D=md549",
+                            "meta": {}
+                        }
+                    }
+                }
+            },
+            "links": {
+                "info": "https://localhost:8000/v2/wikis/md549/",
+                "download": "https://localhost:8000/v2/wikis/md549/content/",
+                "self": "https://localhost:8000/v2/wikis/md549/"
+            },
+            "attributes": {
+                "kind": "file",
+                "name": "test1Ω≈ç√∫˜µ≤≥≥÷åß∂ƒ©˙∆∆˚¬…æ",
+                "date_modified": "2019-10-31T14:55:01.846744Z",
+                "extra": {
+                    "version": 2
+                },
+                "content_type": "text/markdown",
+                "path": "/md549",
+                "current_user_can_comment": true,
+                "materialized_path": "/md549",
+                "size": 632
+            },
+            "type": "wikis",
+            "id": "md549"
+        }
+    ],
+    "meta": {
+        "total": 11,
+        "per_page": 10,
+        "version": "2.18"
+    },
+    "links": {
+        "self": "https://localhost:8000/v2/registrations/fxehm/wikis/",
+        "first": null,
+        "last": "https://localhost:8000/v2/registrations/fxehm/wikis/?page=2",
+        "prev": null,
+        "next": "https://localhost:8000/v2/registrations/fxehm/wikis/?page=2"
+    }
+}

--- a/IA/tests/fixtures/wiki-metadata-response-page-2.json
+++ b/IA/tests/fixtures/wiki-metadata-response-page-2.json
@@ -1,0 +1,72 @@
+{
+    "data": [
+        {
+            "relationships": {
+                "node": {
+                    "data": {
+                        "type": "registrations",
+                        "id": "fxehm"
+                    },
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/registrations/fxehm/",
+                            "meta": {}
+                        }
+                    }
+                },
+                "user": {
+                    "data": {
+                        "type": "users",
+                        "id": "wm28y"
+                    },
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/users/wm28y/",
+                            "meta": {}
+                        }
+                    }
+                },
+                "comments": {
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/registrations/fxehm/comments/?filter%5Btarget%5D=p8kxa",
+                            "meta": {}
+                        }
+                    }
+                }
+            },
+            "links": {
+                "info": "https://localhost:8000/v2/wikis/p8kxa/",
+                "download": "https://localhost:8000/v2/wikis/p8kxa/content/",
+                "self": "https://localhost:8000/v2/wikis/p8kxa/"
+            },
+            "attributes": {
+                "kind": "file",
+                "name": "test2",
+                "date_modified": "2019-10-31T14:55:01.288916Z",
+                "extra": {
+                    "version": 2
+                },
+                "content_type": "text/markdown",
+                "path": "/p8kxa",
+                "current_user_can_comment": true,
+                "materialized_path": "/p8kxa",
+                "size": 68
+            },
+            "type": "wikis",
+            "id": "p8kxa"
+        }
+    ],
+    "meta": {
+        "total": 11,
+        "per_page": 10,
+        "version": "2.18"
+    },
+    "links": {
+        "self": "https://localhost:8000/v2/registrations/fxehm/wikis/?page=2",
+        "first": "https://localhost:8000/v2/registrations/fxehm/wikis/",
+        "last": null,
+        "prev": "https://localhost:8000/v2/registrations/fxehm/wikis/",
+        "next": null
+    }
+}

--- a/IA/tests/fixtures/wiki-metadata-response.json
+++ b/IA/tests/fixtures/wiki-metadata-response.json
@@ -1,0 +1,184 @@
+{
+    "data": [
+        {
+            "relationships": {
+                "node": {
+                    "data": {
+                        "type": "registrations",
+                        "id": "fxehm"
+                    },
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/registrations/fxehm/",
+                            "meta": {}
+                        }
+                    }
+                },
+                "user": {
+                    "data": {
+                        "type": "users",
+                        "id": "wm28y"
+                    },
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/users/wm28y/",
+                            "meta": {}
+                        }
+                    }
+                },
+                "comments": {
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/registrations/fxehm/comments/?filter%5Btarget%5D=dtns3",
+                            "meta": {}
+                        }
+                    }
+                }
+            },
+            "links": {
+                "info": "https://localhost:8000/v2/wikis/dtns3/",
+                "download": "https://localhost:8000/v2/wikis/dtns3/content/",
+                "self": "https://localhost:8000/v2/wikis/dtns3/"
+            },
+            "attributes": {
+                "kind": "file",
+                "name": "home",
+                "date_modified": "2019-10-31T14:55:02.352330Z",
+                "extra": {
+                    "version": 1
+                },
+                "content_type": "text/markdown",
+                "path": "/dtns3",
+                "current_user_can_comment": true,
+                "materialized_path": "/dtns3",
+                "size": 860
+            },
+            "type": "wikis",
+            "id": "dtns3"
+        },
+        {
+            "relationships": {
+                "node": {
+                    "data": {
+                        "type": "registrations",
+                        "id": "fxehm"
+                    },
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/registrations/fxehm/",
+                            "meta": {}
+                        }
+                    }
+                },
+                "user": {
+                    "data": {
+                        "type": "users",
+                        "id": "wm28y"
+                    },
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/users/wm28y/",
+                            "meta": {}
+                        }
+                    }
+                },
+                "comments": {
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/registrations/fxehm/comments/?filter%5Btarget%5D=md549",
+                            "meta": {}
+                        }
+                    }
+                }
+            },
+            "links": {
+                "info": "https://localhost:8000/v2/wikis/md549/",
+                "download": "https://localhost:8000/v2/wikis/md549/content/",
+                "self": "https://localhost:8000/v2/wikis/md549/"
+            },
+            "attributes": {
+                "kind": "file",
+                "name": "test1Ω≈ç√∫˜µ≤≥≥÷åß∂ƒ©˙∆∆˚¬…æ",
+                "date_modified": "2019-10-31T14:55:01.846744Z",
+                "extra": {
+                    "version": 2
+                },
+                "content_type": "text/markdown",
+                "path": "/md549",
+                "current_user_can_comment": true,
+                "materialized_path": "/md549",
+                "size": 632
+            },
+            "type": "wikis",
+            "id": "md549"
+        },
+        {
+            "relationships": {
+                "node": {
+                    "data": {
+                        "type": "registrations",
+                        "id": "fxehm"
+                    },
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/registrations/fxehm/",
+                            "meta": {}
+                        }
+                    }
+                },
+                "user": {
+                    "data": {
+                        "type": "users",
+                        "id": "wm28y"
+                    },
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/users/wm28y/",
+                            "meta": {}
+                        }
+                    }
+                },
+                "comments": {
+                    "links": {
+                        "related": {
+                            "href": "https://localhost:8000/v2/registrations/fxehm/comments/?filter%5Btarget%5D=p8kxa",
+                            "meta": {}
+                        }
+                    }
+                }
+            },
+            "links": {
+                "info": "https://localhost:8000/v2/wikis/p8kxa/",
+                "download": "https://localhost:8000/v2/wikis/p8kxa/content/",
+                "self": "https://localhost:8000/v2/wikis/p8kxa/"
+            },
+            "attributes": {
+                "kind": "file",
+                "name": "test2",
+                "date_modified": "2019-10-31T14:55:01.288916Z",
+                "extra": {
+                    "version": 2
+                },
+                "content_type": "text/markdown",
+                "path": "/p8kxa",
+                "current_user_can_comment": true,
+                "materialized_path": "/p8kxa",
+                "size": 68
+            },
+            "type": "wikis",
+            "id": "p8kxa"
+        }
+    ],
+    "meta": {
+        "total": 3,
+        "per_page": 10,
+        "version": "2.18"
+    },
+    "links": {
+        "self": "https://localhost:8000/v2/registrations/fxehm/wikis/",
+        "first": null,
+        "last": null,
+        "prev": null,
+        "next": null
+    }
+}

--- a/IA/tests/test_wiki_dump.py
+++ b/IA/tests/test_wiki_dump.py
@@ -75,13 +75,13 @@ class TestWikiDumper(unittest.TestCase):
             ]
 
     @responses.activate
-    @mock.patch('IA.wiki_dump.SLEEP_PERIOD', return_value=1)
-    def test_wiki_dump_retry(self, mock_sleep):
+    def test_wiki_dump_retry(self):
         responses.add(
             responses.Response(
                 responses.GET,
                 'https://localhost:8000/v2/registrations/fxehm/wikis/?page=1',
-                status=500,
+                status=429,
+                headers={'Retry-After': '1'},
             )
         )
         responses.add(

--- a/IA/tests/test_wiki_dump.py
+++ b/IA/tests/test_wiki_dump.py
@@ -1,0 +1,171 @@
+import os
+import asyncio
+import json
+import mock
+from mock import call
+import unittest
+import responses
+from nose.tools import assert_equal
+from IA.wiki_dump import main
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def wiki_metadata():
+    with open(os.path.join(HERE, 'fixtures/wiki-metadata-response.json'), 'r') as fp:
+        return json.loads(fp.read())
+
+
+def wiki_metadata_two_pages():
+    with open(os.path.join(HERE, 'fixtures/wiki-metadata-response-page-1.json'), 'r') as fp:
+        page1 = json.loads(fp.read())
+
+    with open(os.path.join(HERE, 'fixtures/wiki-metadata-response-page-2.json'), 'r') as fp:
+        page2 = json.loads(fp.read())
+
+    return page1, page2
+
+
+class TestWikiDumper(unittest.TestCase):
+
+    @responses.activate
+    def test_wiki_dump(self):
+        responses.add(
+            responses.Response(
+                responses.GET,
+                'https://localhost:8000/v2/registrations/fxehm/wikis/?page=1',
+                json=wiki_metadata(),
+            )
+        )
+        responses.add(
+            responses.Response(
+                responses.GET,
+                'https://localhost:8000/v2/wikis/dtns3/content/',
+                body=b'dtns3 data',
+            ),
+        )
+        responses.add(
+            responses.Response(
+                responses.GET,
+                'https://localhost:8000/v2/wikis/md549/content/',
+                body=b'md549 data',
+            ),
+        )
+        responses.add(
+            responses.Response(
+                responses.GET,
+                'https://localhost:8000/v2/wikis/p8kxa/content/',
+                body=b'p8kxa data',
+            ),
+        )
+
+        with mock.patch('builtins.open', mock.mock_open()) as m:
+            asyncio.run(main('fxehm'))
+            assert m.call_args_list == [
+                call('/home.md', 'wb'),
+                call('/test1Ω≈ç√∫˜µ≤≥≥÷åß∂ƒ©˙∆∆˚¬…æ.md', 'wb'),
+                call('/test2.md', 'wb')
+            ]
+            handle = m()
+
+            assert handle.write.call_args_list == [
+                call(b'dtns3 data'),
+                call(b'md549 data'),
+                call(b'p8kxa data')
+            ]
+
+    @responses.activate
+    @mock.patch('IA.wiki_dump.SLEEP_PERIOD', return_value=1)
+    def test_wiki_dump_retry(self, mock_sleep):
+        responses.add(
+            responses.Response(
+                responses.GET,
+                'https://localhost:8000/v2/registrations/fxehm/wikis/?page=1',
+                status=500,
+            )
+        )
+        responses.add(
+            responses.Response(
+                responses.GET,
+                'https://localhost:8000/v2/registrations/fxehm/wikis/?page=1',
+                json=wiki_metadata(),
+            )
+        )
+        responses.add(
+            responses.Response(
+                responses.GET,
+                'https://localhost:8000/v2/wikis/dtns3/content/',
+                body=b'dtns3 data',
+            ),
+        )
+        responses.add(
+            responses.Response(
+                responses.GET,
+                'https://localhost:8000/v2/wikis/md549/content/',
+                body=b'md549 data',
+            ),
+        )
+        responses.add(
+            responses.Response(
+                responses.GET,
+                'https://localhost:8000/v2/wikis/p8kxa/content/',
+                body=b'p8kxa data',
+            ),
+        )
+
+        with mock.patch('builtins.open', mock.mock_open()) as m:
+            asyncio.run(main('fxehm'))
+            assert m.call_args_list == [
+                call('/home.md', 'wb'),
+                call('/test1Ω≈ç√∫˜µ≤≥≥÷åß∂ƒ©˙∆∆˚¬…æ.md', 'wb'),
+                call('/test2.md', 'wb')
+            ]
+            handle = m()
+
+            assert handle.write.call_args_list == [
+                call(b'dtns3 data'),
+                call(b'md549 data'),
+                call(b'p8kxa data')
+            ]
+
+    @responses.activate
+    def test_wiki_dump_multiple_pages(self):
+        page1, page2 = wiki_metadata_two_pages()
+
+        responses.add(
+            responses.Response(
+                responses.GET,
+                'https://localhost:8000/v2/registrations/fxehm/wikis/?page=1',
+                json=page1,
+            )
+        )
+        responses.add(
+            responses.Response(
+                responses.GET,
+                'https://localhost:8000/v2/registrations/fxehm/wikis/?page=2',
+                json=page2,
+            )
+        )
+
+        data = page1['data'] + page2['data']
+        for wiki in data:
+            responses.add(
+                responses.Response(
+                    responses.GET,
+                    f'https://localhost:8000/v2/wikis{wiki["attributes"]["path"]}/content/',
+                    body=f'{wiki["attributes"]["path"]} data',
+                ),
+            )
+
+        with mock.patch('builtins.open', mock.mock_open()) as m:
+            asyncio.run(main('fxehm'))
+            assert_equal(
+                m.call_args_list,
+                [call(f'/{wiki["attributes"]["name"]}.md', 'wb') for wiki in data]
+            )
+
+            handle = m()
+            assert_equal(
+                handle.write.call_args_list,
+                [call(f'{wiki["attributes"]["path"]} data'.encode()) for wiki in data]
+            )

--- a/IA/wiki_dump.py
+++ b/IA/wiki_dump.py
@@ -1,0 +1,103 @@
+import os
+import math
+import asyncio
+import requests
+import argparse
+from ratelimit import sleep_and_retry
+from ratelimit.exception import RateLimitException
+from settings import SLEEP_PERIOD, OSF_API_URL
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+class WikiDumpError(Exception):
+    pass
+
+
+@sleep_and_retry
+def get_with_retry(url):
+    resp = requests.get(url)
+    if resp.status_code in (429, 500, 503):
+        raise RateLimitException(
+            message='Too many requests, sleeping.',
+            period_remaining=SLEEP_PERIOD
+        )  # This will be caught by @sleep_and_retry and retried
+
+    return resp.json()
+
+
+@sleep_and_retry
+async def get_wiki_pages(guid, page, result={}):
+    url = f'{OSF_API_URL}v2/registrations/{guid}/wikis/?page={page}'
+    resp = requests.get(url)
+    if resp.status_code in (429, 500, 503):
+        raise RateLimitException(
+            message='Too many requests, sleeping.',
+            period_remaining=SLEEP_PERIOD
+        )  # This will be caught by @sleep_and_retry and retried
+
+    result[page] = requests.get(url).json()['data']
+    return result
+
+
+@sleep_and_retry
+async def write_wiki_content(page):
+    resp = requests.get(page['links']['download'])
+    if resp.status_code in (429, 500, 503):
+        raise RateLimitException(
+            message='Too many requests, sleeping.',
+            period_remaining=SLEEP_PERIOD
+        )  # This will be caught by @sleep_and_retry and retried
+
+    with open(os.path.join(HERE, f'/{page["attributes"]["name"]}.md'), 'wb') as fp:
+        fp.write(resp.content)
+
+
+async def main(guid):
+    """
+    Usually asynchronous requests/writes are reserved for times when it's truely necessary, but
+    given the fact that we have like 4 days left in the sprint and this going to be the first
+    py3 thing in the repo, I've decided to whip out the big guns and concurrently gather all
+    wiki pages simultaneously (except for the first one) and then stream them all to local
+    files simultaneously just because it's easy to do with py3 and will save a nano-second or two.
+
+    :param guid:
+    :return:
+    """
+
+    url = f'{OSF_API_URL}v2/registrations/{guid}/wikis/?page=1'
+    tasks = []
+
+    data = get_with_retry(url)
+    result = {1: data['data']}
+
+    if data['links']['next'] is not None:
+        pages = math.ceil(int(data['meta']['total']) / int(data['meta']['per_page']))
+        for i in range(1, pages):
+            task = get_wiki_pages(guid, i + 1, result)
+            tasks.append(task)
+
+    await asyncio.gather(*tasks)
+    pages_as_list = []
+    # through the magic of async all our pages have loaded.
+    for page in list(result.values()):
+        pages_as_list += page
+
+    write_tasks = []
+    for page in pages_as_list:
+        write_tasks.append(write_wiki_content(page))
+
+    await asyncio.gather(*write_tasks)
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-id',
+        '--guid',
+        help='The guid of the registration if who\'s wiki you want to dump.',
+        required=True
+    )
+    args = parser.parse_args()
+
+    guid = args.guid
+    asyncio.run(main(guid))

--- a/settings/defaults.py
+++ b/settings/defaults.py
@@ -1,4 +1,2 @@
 OSF_API_URL = 'https://localhost:8000/'
 OSF_LOGS_URL = 'v2/registrations/{}/logs/?page[size]={}'
-
-SLEEP_PERIOD = 10

--- a/settings/defaults.py
+++ b/settings/defaults.py
@@ -1,2 +1,4 @@
 OSF_API_URL = 'https://localhost:8000/'
 OSF_LOGS_URL = 'v2/registrations/{}/logs/?page[size]={}'
+
+SLEEP_PERIOD = 10


### PR DESCRIPTION
⚠️ Don't use Docker for this! ⚠️ 

## Purpose

Dump wiki markdown files  to local directory.

## Changes

- add little script for dumping and writing to file.

## QA Notes

Ok devs to test this you're going to have to dust off your trusty old virtualenv, this runs specifically in python3 so you're going to have specify that on  creation with something like ` mkvirtualenv IA --python=python3` then `pip install -r requirements.txt`  that should cover dependencies. 

## Documentation

Not user facing

## Side Effects

None that I know of.
 
## Ticket

https://openscience.atlassian.net/browse/ENG-1155