### PR TITLE
Wikis and locals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+local.py

--- a/IA/IA_wiki_dump.py
+++ b/IA/IA_wiki_dump.py
@@ -13,12 +13,9 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 async def write_wiki_content(page, destination, guid):
     resp = get_with_retry(page['links']['download'], retry_on=(429,))
     file_destination_path = os.path.join(HERE, destination, guid, 'wikis')
-    
-    try:
-        os.mkdir(file_destination_path)
-    except FileExistsError:
-        pass
-    
+
+    os.makedirs(file_destination_path, exist_ok=True)
+
     file_path = os.path.join(file_destination_path, f'{page["attributes"]["name"]}.md')
     with open(file_path, 'wb') as fp:
         fp.write(resp.content)
@@ -51,7 +48,7 @@ if __name__ == '__main__':
         '-g',
         '--guid',
         help='The guid of the registration of who\'s wiki you want to dump.',
-        required=True
+        required=True,
     )
     args = parser.parse_args()
 

--- a/IA/IA_wiki_dump.py
+++ b/IA/IA_wiki_dump.py
@@ -12,7 +12,14 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 
 async def write_wiki_content(page, destination, guid):
     resp = get_with_retry(page['links']['download'], retry_on=(429,))
-    file_path = os.path.join(HERE, destination, guid, f'{page["attributes"]["name"]}.md')
+    file_destination_path = os.path.join(HERE, destination, guid, 'wikis')
+    
+    try:
+        os.mkdir(file_destination_path)
+    except FileExistsError:
+        pass
+    
+    file_path = os.path.join(file_destination_path, f'{page["attributes"]["name"]}.md')
     with open(file_path, 'wb') as fp:
         fp.write(resp.content)
 

--- a/IA/tests/test_IA_wiki_dump.py
+++ b/IA/tests/test_IA_wiki_dump.py
@@ -35,7 +35,7 @@ class TestWikiDumper(unittest.TestCase):
                 responses.GET,
                 'http://localhost:8000/v2/registrations/fxehm/wikis/',
                 json=wiki_metadata(),
-            )
+            ),
         )
         responses.add(
             responses.Response(
@@ -61,18 +61,18 @@ class TestWikiDumper(unittest.TestCase):
 
         with mock.patch('builtins.open', mock.mock_open()) as m:
             asyncio.run(main('fxehm', ''))
-            mock_path = os.path.abspath(os.path.join(HERE, '..', 'fxehm'))
+            mock_path = os.path.abspath(os.path.join(HERE, '..', 'fxehm', 'wikis'))
             assert m.call_args_list == [
                 call(os.path.join(mock_path, 'home.md'), 'wb'),
                 call(os.path.join(mock_path, 'test1Ω≈ç√∫˜µ≤≥≥÷åß∂ƒ©˙∆∆˚¬…æ.md'), 'wb'),
-                call(os.path.join(mock_path, 'test2.md'), 'wb')
+                call(os.path.join(mock_path, 'test2.md'), 'wb'),
             ]
             handle = m()
 
             assert handle.write.call_args_list == [
                 call(b'dtns3 data'),
                 call(b'md549 data'),
-                call(b'p8kxa data')
+                call(b'p8kxa data'),
             ]
 
     @responses.activate
@@ -83,14 +83,14 @@ class TestWikiDumper(unittest.TestCase):
                 'http://localhost:8000/v2/registrations/fxehm/wikis/',
                 status=429,
                 headers={'Retry-After': '1'},
-            )
+            ),
         )
         responses.add(
             responses.Response(
                 responses.GET,
                 'http://localhost:8000/v2/registrations/fxehm/wikis/',
                 json=wiki_metadata(),
-            )
+            ),
         )
         responses.add(
             responses.Response(
@@ -116,18 +116,18 @@ class TestWikiDumper(unittest.TestCase):
 
         with mock.patch('builtins.open', mock.mock_open()) as m:
             asyncio.run(main('fxehm', ''))
-            mock_path = os.path.abspath(os.path.join(HERE, '..', 'fxehm'))
+            mock_path = os.path.abspath(os.path.join(HERE, '..', 'fxehm', 'wikis'))
             assert m.call_args_list == [
                 call(os.path.join(mock_path, 'home.md'), 'wb'),
                 call(os.path.join(mock_path, 'test1Ω≈ç√∫˜µ≤≥≥÷åß∂ƒ©˙∆∆˚¬…æ.md'), 'wb'),
-                call(os.path.join(mock_path, 'test2.md'), 'wb')
+                call(os.path.join(mock_path, 'test2.md'), 'wb'),
             ]
             handle = m()
 
             assert handle.write.call_args_list == [
                 call(b'dtns3 data'),
                 call(b'md549 data'),
-                call(b'p8kxa data')
+                call(b'p8kxa data'),
             ]
 
     @responses.activate
@@ -139,7 +139,7 @@ class TestWikiDumper(unittest.TestCase):
                 'http://localhost:8000/v2/registrations/fxehm/wikis/',
                 json=page1,
                 match_querystring=True,
-            )
+            ),
         )
         responses.add(
             responses.Response(
@@ -147,7 +147,7 @@ class TestWikiDumper(unittest.TestCase):
                 'http://localhost:8000/v2/registrations/fxehm/wikis/?page=2',
                 json=page2,
                 match_querystring=True,
-            )
+            ),
         )
 
         data = page1['data'] + page2['data']
@@ -162,18 +162,26 @@ class TestWikiDumper(unittest.TestCase):
 
         with mock.patch('builtins.open', mock.mock_open()) as m:
             asyncio.run(main('fxehm', ''))
-            mock_path = os.path.abspath(os.path.join(HERE, '..', 'fxehm'))
+            mock_path = os.path.abspath(os.path.join(HERE, '..', 'fxehm', 'wikis'))
             assert_equal(
                 m.call_args_list,
-                [call(
-                    os.path.join(
-                        mock_path, f'{wiki["attributes"]["name"]}.md'), 'wb') for wiki in data]
+                [
+                    call(
+                        os.path.join(
+                            mock_path, f'{wiki["attributes"]["name"]}.md',
+                        ), 'wb',
+                    ) for wiki in data
+                ],
             )
 
             handle = m()
             assert_equal(
                 handle.write.call_args_list,
-                [call(
-                    os.path.join(
-                        mock_path, f'{wiki["attributes"]["path"]} data').encode()) for wiki in data]
+                [
+                    call(
+                        os.path.join(
+                            mock_path, f'{wiki["attributes"]["path"]} data',
+                        ).encode(),
+                    ) for wiki in data
+                ],
             )

--- a/settings/__init__.py
+++ b/settings/__init__.py
@@ -3,7 +3,7 @@ import warnings
 from .defaults import *  # noqa
 
 try:
-    from .locals import *  # noqa
+    from .local import *  # noqa
 except ImportError:
     warnings.warn(
         'No settings file found. Did you remember to '


### PR DESCRIPTION
## Purpose

Make pigeon a bit more consistent with locals and wikis

## Changes

1. Create a `wikis` directory to hold wiki files
2. Use `local.py` (rather than `locals.py`) to match `local-dist.py` and osf usage

## QA Notes

  - Does this change require a data migration? If so, what data will we migrate? No
  - What is the level of risk? Low
    - Any permissions code touched? No
    - Is this an additive or subtractive change, other? Additive plus one dev feature
  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?) Dev test
    - If verifying through API, what's the new version? Please include the endpoints in PR notes or Dev docs.
  - What features or workflows might this change impact? Wiki acquisition and setup
  - How will this impact performance? It will not affect performance


## Documentation

No docs updates

## Side Effects

People who already have locals.py will need to rename to local.py.

## Ticket

Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/ENG-1265
