### PR TITLE
[ENG-2577][WIP] Make OSF Pigeon use IA collections for Branded Registries

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,4 @@
+import mock
 import pytest
 import responses
 from osf_pigeon import settings
@@ -16,7 +17,7 @@ def mock_waterbutler(guid, zip_data):
 
 
 @pytest.fixture
-def mock_osf_api(guid):
+def mock_osf_api():
     with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
         yield rsps
 
@@ -29,3 +30,17 @@ def mock_datacite(guid):
             responses.GET,
             f'{settings.DATACITE_URL}metadata/{doi}', status=200)
         yield rsps
+
+
+@pytest.fixture
+def mock_ia_client():
+    with mock.patch('osf_pigeon.pigeon.internetarchive.get_session') as mock_ia:
+        mock_session = mock.Mock()
+        mock_ia_item = mock.Mock()
+        mock_ia.return_value = mock_session
+        mock_session.get_item.return_value = mock_ia_item
+
+        # ⬇️ we only pass one mock into the test
+        mock_ia.session = mock_session
+        mock_ia.item = mock_ia_item
+        yield mock_ia

--- a/osf_pigeon/settings/defaults.py
+++ b/osf_pigeon/settings/defaults.py
@@ -8,7 +8,8 @@ DATACITE_PREFIX = '10.17605'  # Datacite's prod DOI prefix
 DATACITE_URL = 'https://mds.datacite.org/'
 
 PAGE_SIZE = 100
-OSF_COLLECTION_NAME = 'cos-dev-sandbox'
+
+OSF_STAGING_COLLECTION_NAME = 'cos-dev-sandbox'
 OSF_BEARER_TOKEN = None
 
 IA_ACCESS_KEY = None

--- a/tests/fixtures/metadata-resp-with-embeds.json
+++ b/tests/fixtures/metadata-resp-with-embeds.json
@@ -87,6 +87,10 @@
                         "href": "http://localhost:8000/v2/providers/registrations/osf/",
                         "meta": {}
                     }
+                },
+                "data": {
+                    "id": "osf",
+                    "type": "registration-providers"
                 }
             },
             "forks": {


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

To give each osf provide it's own IA Collection!

## Changes

- break upload activity into it's own function
- send collection specific metadata header to IA
- adds tests and mocking

## QA Notes

Dev test

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

No new docs

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-2577