### PR TITLE
[ENG-2578] Sync metadata only

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,17 @@ Install
 
 Simply install the package using python's package manager pip with bash:
  
- ``pip3 install osf_pigeon``
+```
+pip3 install osf_pigeon
+```
+
  
 To use for local development just remember to install the developer requirements using:
 
- ``pip3 install -r dev.txt``
+```
+pip3 install -r dev.txt
+```
+
 
 Use
 ============
@@ -32,9 +38,9 @@ Assuming the registration is fully public and the DOI has been minted properly a
 Run from package
 ============
 
-
 Simply import the module and enter a guid with credentials::
 
+```
  from osf_pigeon.pigeon import main
 
  main(
@@ -45,16 +51,36 @@ Simply import the module and enter a guid with credentials::
     ia_access_key='test_datacite_password',
     ia_secret_key='test_datacite_password',
  )
-
+```
 That's it!
+
+
+Sync Metadata without files
+============
+
+```
+ from osf_pigeon.pigeon import sync_metadata
+
+ sync_metadata(
+    'guid0',
+    ia_access_key='test_datacite_password',
+    ia_secret_key='test_datacite_password',
+    metadata={
+        'title': 'This is the title',
+        'anything': 'This is isn't validated'
+    }
+)
+```
+
+The IA bucket may take several minutes to reflect changes.
 
 Run as script
 ============
 
 To run as script just -m to execute the module:
-
+```
  python3 -m osf_pigeon -g u8p3q 
-
+```
 
 Running in development
 ========================
@@ -64,9 +90,10 @@ Tests
 ============
 
 Running tests are easy enough just::
-
+```
  pip3 install -r dev.txt
  python3 -m pytest . 
+```
 
 
 Linting

--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,4 @@
+import mock
 import pytest
 import responses
 from osf_pigeon import settings
@@ -16,7 +17,7 @@ def mock_waterbutler(guid, zip_data):
 
 
 @pytest.fixture
-def mock_osf_api(guid):
+def mock_osf_api():
     with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
         yield rsps
 
@@ -29,3 +30,17 @@ def mock_datacite(guid):
             responses.GET,
             f'{settings.DATACITE_URL}metadata/{doi}', status=200)
         yield rsps
+
+
+@pytest.fixture
+def mock_ia_client():
+    with mock.patch('osf_pigeon.pigeon.internetarchive.get_session') as mock_ia:
+        mock_session = mock.Mock()
+        mock_ia_item = mock.Mock()
+        mock_ia.return_value = mock_session
+        mock_session.get_item.return_value = mock_ia_item
+
+        # ⬇️ just so we only pass one mock into the test, but can refference the item/session directly
+        mock_ia.session = mock_session
+        mock_ia.item = mock_ia_item
+        yield mock_ia

--- a/conftest.py
+++ b/conftest.py
@@ -40,7 +40,7 @@ def mock_ia_client():
         mock_ia.return_value = mock_session
         mock_session.get_item.return_value = mock_ia_item
 
-        # ⬇️ just so we only pass one mock into the test, but can refference the item/session directly
+        # ⬇️ we only pass one mock into the test
         mock_ia.session = mock_session
         mock_ia.item = mock_ia_item
         yield mock_ia

--- a/osf_pigeon/pigeon.py
+++ b/osf_pigeon/pigeon.py
@@ -163,17 +163,9 @@ def main(
         )
 
         zip_data = create_zip_data(temp_dir)
-
-        session = internetarchive.get_session(
-            config={
-                's3': {
-                    'access': ia_access_key,
-                    'secret': ia_secret_key
-                }
-            }
-        )
-        ia_item = session.get_item(guid)
         metadata = get_metadata(temp_dir, 'registration.json')
+
+        ia_item = get_ia_item(guid, ia_access_key, ia_secret_key)
 
         ia_item.upload(
             {'bag.zip': zip_data},
@@ -327,3 +319,20 @@ async def get_paginated_data(url, parse_json=None):
         return pages_as_list
     else:
         return data
+
+
+def get_ia_item(guid, ia_access_key, ia_secret_key):
+    session = internetarchive.get_session(
+        config={
+            's3': {
+                'access': ia_access_key,
+                'secret': ia_secret_key
+            }
+        }
+    )
+    return session.get_item(guid)
+
+
+def sync_metadata(guid, metadata, ia_access_key, ia_secret_key):
+    ia_item = get_ia_item(guid, ia_access_key, ia_secret_key)
+    modify_metadata_with_retry(ia_item, metadata)

--- a/tests/test_pigeon.py
+++ b/tests/test_pigeon.py
@@ -13,7 +13,8 @@ from osf_pigeon.pigeon import (
     create_zip_data,
     get_metadata,
     modify_metadata_with_retry,
-    get_contributors
+    get_contributors,
+    sync_metadata
 )
 import internetarchive
 import zipfile
@@ -278,6 +279,17 @@ class TestMetadata:
 
         assert len(mock_ia_item.mock_calls) == 1
         assert mock_ia_item.mock_calls[0][1][0] == metadata
+
+    def test_modify_metadata_only(self, mock_ia_client, guid):
+        metadata = {
+            'title': 'Test Component',
+            'description': 'Test Description',
+            'date': '2017-12-20',
+            'contributor': 'Center for Open Science',
+        }
+        sync_metadata(guid, metadata, 'notrealaccesskey', 'notrealsecretkey')
+        mock_ia_client.session.get_item.assert_called_with('guid0')
+        mock_ia_client.item.modify_metadata.assert_called_with(metadata)
 
     def test_modify_metadata_with_retry(self, temp_dir, test_node_json):
         metadata = {


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Make it so there's a function that allows us to sync metadata with IA without uploading raw files again.

## Changes

- creates a new `sync_metadata` function with tests/mocking
- randomly cleans up readme

## QA Notes

dev tests for now

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

new feature, no new docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-2578