### PR TITLE
Format deactivated accounts properly

### DIFF
--- a/osf_pigeon/pigeon.py
+++ b/osf_pigeon/pigeon.py
@@ -230,16 +230,21 @@ async def get_additional_contributor_info(response):
     contributor_data_list = []
     for contributor in response["data"]:
         contributor_data = {}
-        embed_data = contributor["embeds"]["users"]["data"]
-        institution_url = embed_data["relationships"]["institutions"]["links"][
-            "related"
-        ]["href"]
-        data = await get_with_retry(institution_url)
-        institution_data = data["data"]
-        institution_list = [
-            institution["attributes"]["name"] for institution in institution_data
-        ]
-        contributor_data["affiliated_institutions"] = institution_list
+        errors = contributor["embeds"]["users"].get('errors')
+        if errors and errors[0]['detail'] == 'The requested user is no longer available.':
+            contributor_data = errors[0]['meta']
+        else:
+            embed_data = contributor["embeds"]["users"]["data"]
+            institution_url = embed_data["relationships"]["institutions"]["links"][
+                "related"
+            ]["href"]
+            data = await get_with_retry(institution_url)
+            institution_data = data["data"]
+            institution_list = [
+                institution["attributes"]["name"] for institution in institution_data
+            ]
+            contributor_data["affiliated_institutions"] = institution_list
+
         contributor.update(contributor_data)
         contributor_data_list.append(contributor)
     response["data"] = contributor_data_list

--- a/osf_pigeon/pigeon.py
+++ b/osf_pigeon/pigeon.py
@@ -51,6 +51,14 @@ async def get_relationship_attribute(key, url, func):
     return {key: list(map(func, data))}
 
 
+def get_contributor_info(contrib):
+    errors = contrib["embeds"]["users"].get('errors')
+    if errors and errors[0]['detail'] == 'The requested user is no longer available.':
+        return errors[0]['meta']['full_name']
+    else:
+        return contrib["embeds"]["users"]["data"]["attributes"]["full_name"]
+
+
 async def get_metadata_for_ia_item(json_metadata):
     """
     This is meant to take the response JSON metadata and format it for IA buckets, this is not
@@ -87,9 +95,7 @@ async def get_metadata_for_ia_item(json_metadata):
             "creator",
             f'{settings.OSF_API_URL}v2/registrations/{json_metadata["data"]["id"]}/contributors/'
             f"?filter[bibliographic]=true&",
-            lambda contrib: contrib["embeds"]["users"]["data"]["attributes"][
-                "full_name"
-            ],
+            get_contributor_info,
         ),
         get_relationship_attribute(
             "affiliated_institutions",


### PR DESCRIPTION
## Purpose

Currently pigeon doesn't know how to handle getting additional contributor infomation for contributors who have had their accounts deactivated, this PR formats that information correctly. 

## Changes

- fixes method for getting institutional affiliation to account for deactivated users
- fixes contributor metadata formatting 

## QA Notes

Should just register now.

## Documentation

🪲 fix, no docs.

## Side Effects

None that I know of.

## Ticket

None
