### PR TITLE
Add Configurable Timeout for Waterbutler

### DIFF
--- a/osf_pigeon/pigeon.py
+++ b/osf_pigeon/pigeon.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from asyncio import events
 from ratelimit import sleep_and_retry
 from ratelimit.exception import RateLimitException
-from aiohttp import ClientSession, http_exceptions
+from aiohttp import ClientSession, ClientTimeout, http_exceptions
 
 import internetarchive
 from datacite import DataCiteMDSClient
@@ -20,7 +20,7 @@ from osf_pigeon import settings
 
 
 async def stream_files_to_dir(from_url, to_dir, name):
-    async with ClientSession() as session:
+    async with ClientSession(timeout=ClientTimeout(total=settings.FILES_TIMEOUT)) as session:
         async with session.get(from_url) as resp:
             with open(os.path.join(to_dir, name), "wb") as fp:
                 async for chunk in resp.content.iter_any():

--- a/osf_pigeon/settings/defaults.py
+++ b/osf_pigeon/settings/defaults.py
@@ -15,6 +15,7 @@ DOI_FORMAT = os.environ.get("DOI_FORMAT")
 OSF_COLLECTION_NAME = os.environ.get("OSF_COLLECTION_NAME")
 ID_VERSION = os.environ.get("ID_VERSION")
 MAX_WORKERS = int(os.environ.get('MAX_WORKERS', 1))
+FILES_TIMEOUT = int(os.environ.get('FILES_TIMEOUT', 300))
 
 REG_ID_TEMPLATE = f"osf-registrations-{{guid}}-{ID_VERSION}"
 PROVIDER_ID_TEMPLATE = f"osf-registration-providers-{{provider_id}}-{ID_VERSION}"


### PR DESCRIPTION
## Purpose

aiohttp's default timeout is 5 minutes, that's not enough time for WB to send us a large zip.

## Changes

- creates a setting var call `FILES_TIMEOUT` that is the timeout in seconds

## QA Notes

  - Does this change require a data migration? If so, what data will we migrate?
  - What is the level of risk?
    - Any permissions code touched?
    - Is this an additive or subtractive change, other?
  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?)
    - If verifying through API, what's the new version? Please include the endpoints in PR notes or Dev docs.
  - What features or workflows might this change impact?
  - How will this impact performance?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

None that I know of.

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
