### PR TITLE
[Hotfix] Limit concurrent pagination

### DIFF
--- a/osf_pigeon/settings/defaults.py
+++ b/osf_pigeon/settings/defaults.py
@@ -15,6 +15,7 @@ DOI_FORMAT = os.environ.get("DOI_FORMAT")
 OSF_COLLECTION_NAME = os.environ.get("OSF_COLLECTION_NAME")
 ID_VERSION = os.environ.get("ID_VERSION")
 MAX_WORKERS = int(os.environ.get('MAX_WORKERS', 1))
+PAGING_SEMAPHORE = int(os.environ.get('PAGING_SEMAPHORE', 10))
 
 REG_ID_TEMPLATE = f"osf-registrations-{{guid}}-{ID_VERSION}"
 PROVIDER_ID_TEMPLATE = f"osf-registration-providers-{{provider_id}}-{ID_VERSION}"


### PR DESCRIPTION
## Purpose
Some registrations have hundreds of pages of logs. Requesting them all concurrently has a negative impact on performace.

## Changes
- Add configurable limit to concurrent pagination
- Minor: don't use mutable defaults

## Side Effects
None expected
