### PR TITLE
Add schema responses to json

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,5 +156,9 @@ Each archived registration includes four json files and one xml file with metada
      affiliated institutions.
   - logs.json
     - A list of all that registrations logs. 
+  - schema_responses.json
+    - A list of all the registration's schema responses. 
+  - registration_schema.json
+    - A copy of the registration schema which the registration is responding to. 
   - datacite.xml
     - This contains the datacite's metadata for the DOI corresponding to that registration,

--- a/osf_pigeon/pigeon.py
+++ b/osf_pigeon/pigeon.py
@@ -409,6 +409,12 @@ async def archive(guid):
                 name="contributors.json",
                 parse_json=get_additional_contributor_info,
             ),
+            dump_json_to_dir(
+                from_url=f"{settings.OSF_API_URL}v2/registrations/{guid}/schema_responses/"
+                f"?page[size]=100",
+                to_dir=os.path.join(temp_dir, "bag"),
+                name="schema_responses.json",
+            ),
         ]
         # only download archived data if there are files
         file_count = metadata["data"]["relationships"]["files"]["links"]["related"][

--- a/osf_pigeon/pigeon.py
+++ b/osf_pigeon/pigeon.py
@@ -415,6 +415,11 @@ async def archive(guid):
                 to_dir=os.path.join(temp_dir, "bag"),
                 name="schema_responses.json",
             ),
+            dump_json_to_dir(
+                from_url=metadata["data"]["relationships"]["registration_schema"]["links"]["related"]["href"],
+                to_dir=os.path.join(temp_dir, "bag"),
+                name="registration_schema.json",
+            ),
         ]
         # only download archived data if there are files
         file_count = metadata["data"]["relationships"]["files"]["links"]["related"][


### PR DESCRIPTION
## Purpose

Add json of all schema responses to IA item each time a schema is updated.

## Changes

- Pulls and uploads a JSON file of the schema responses.

## QA Notes

I tested this, creating this IA item https://archive.org/details/osf-registrations-mrfty-staging_v2

## Documentation

No new docs.

## Side Effects

None that I know of.

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
